### PR TITLE
Update Postgres Docker image version

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -114,9 +118,9 @@
         "filename": "docker-compose.yaml",
         "hashed_secret": "b3054ff0797ff0b2bbce03ec897fe63e0b6490e0",
         "is_verified": true,
-        "line_number": 18
+        "line_number": 25
       }
     ]
   },
-  "generated_at": "2024-02-08T12:20:59Z"
+  "generated_at": "2024-08-13T07:58:33Z"
 }

--- a/docker-compose.migrate.yaml
+++ b/docker-compose.migrate.yaml
@@ -39,7 +39,7 @@ services:
       - ./scripts:/scripts
 
   ffc-sfd-permissions-api-postgres:
-    image: postgres:11.4-alpine
+    image: postgres:15
     environment: *common-postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
   
 
   ffc-sfd-permissions-api-postgres:
-    image: postgres:11.4-alpine
+    image: postgres:15
     environment:
       POSTGRES_DB: ffc_sfd_permissions_api
       POSTGRES_PASSWORD: ppp

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-sfd-permissions-api",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "",
   "homepage": "github.com?owner=defra&repo=ffc-sfd-permissions-api&organization=defra",
   "main": "app/index.js",
@@ -16,7 +16,10 @@
     "start:debug": "nodemon --inspect-brk=0.0.0.0 --ext js --legacy-watch app/index.js"
   },
   "author": "Defra",
-  "contributors": [],
+  "contributors": [
+    "Fay Toward <fay.toward@defra.gov.uk>",
+    "Rana Salem <rana.salem@defra.gov.uk>"
+  ],
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@hapi/hapi": "21.3.2",


### PR DESCRIPTION
Changes in this PR are based on an email ADP sent to John on 20th May where they mention they would upgrade the current image version (postgres:11.4-alpine) to use postgres:15. John mentioned that we'd update our local development image to 15 as well to match, so this PR is for making those updates.
